### PR TITLE
Add Docker packaging and an external integration setup guide

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Allow only inputs needed by the multi-stage build.
+**
+!Dockerfile
+!.dockerignore
+!package.json
+!package-lock.json
+!tsconfig.json
+!src/
+!src/**
+!driver.json
+!eiscp.png
+!LICENSE
+!logos/
+!logos/**
+!docker/
+!docker/healthcheck.mjs

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,10 +24,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -48,11 +48,11 @@ jobs:
             platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -62,8 +62,26 @@ jobs:
       - name: Test default command and persistence without LAN access
         run: bash docker/smoke.sh uc-intg-onkyo-avr:smoke
 
+  release-gate:
+    if: >-
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish &&
+       github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Require release commit on the repository default branch
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: bash docker/release-gate.sh
+
   publish:
-    needs: [test, build]
+    needs: [test, build, release-gate]
     if: >-
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
       (github.event_name == 'workflow_dispatch' && inputs.publish &&
@@ -73,10 +91,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: .nvmrc
       - name: Validate versions and generate image tags
@@ -90,16 +108,16 @@ jobs:
             printf '%s\n' "$TAGS"
             echo EOF
           } >> "$GITHUB_OUTPUT"
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
           platforms: arm64
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,110 @@
+name: Docker
+
+on:
+  pull_request:
+  push:
+    branches: [main, "feat/**"]
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish a development image from the default branch
+        type: boolean
+        default: false
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run code-check
+      - run: docker compose config --quiet
+
+  build:
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: false
+          load: true
+          tags: uc-intg-onkyo-avr:smoke
+      - name: Test default command and persistence without LAN access
+        run: bash docker/smoke.sh uc-intg-onkyo-avr:smoke
+
+  publish:
+    needs: [test, build]
+    if: >-
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish &&
+       github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+      - name: Validate versions and generate image tags
+        id: tags
+        run: |
+          test "$(jq -r .version package.json)" = "$(jq -r .version driver.json)"
+          export IMAGE_VERSION="$(jq -r .version package.json)"
+          TAGS=$(node docker/image-tags.mjs)
+          {
+            echo 'tags<<EOF'
+            printf '%s\n' "$TAGS"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+# Keep aligned with .nvmrc; the digest pins the multi-platform image index.
+ARG NODE_IMAGE=node:22.22.0-bookworm-slim@sha256:dd9d21971ec4395903fa6143c2b9267d048ae01ca6d3ea96f16cb30df6187d94
+FROM ${NODE_IMAGE} AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM ${NODE_IMAGE} AS production-dependencies
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+FROM ${NODE_IMAGE} AS runtime
+ENV NODE_ENV=production \
+    UC_CONFIG_HOME=/config \
+    UC_INTEGRATION_INTERFACE=0.0.0.0 \
+    UC_INTEGRATION_HTTP_PORT=9090
+WORKDIR /app
+COPY --from=production-dependencies /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY package.json driver.json eiscp.png LICENSE ./
+COPY logos ./logos
+COPY docker/healthcheck.mjs ./docker/healthcheck.mjs
+# Fail rather than shipping mismatched release metadata.
+RUN node -e "const fs=require('fs');if(JSON.parse(fs.readFileSync('driver.json')).version!==JSON.parse(fs.readFileSync('package.json')).version)process.exit(1)" \
+    && mkdir /config && chown node:node /config
+USER node
+VOLUME ["/config"]
+EXPOSE 9090/tcp
+STOPSIGNAL SIGTERM
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 CMD ["node", "docker/healthcheck.mjs"]
+CMD ["node", "dist/driver.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1
 # Keep aligned with .nvmrc; the digest pins the multi-platform image index.
 ARG NODE_IMAGE=node:22.22.0-bookworm-slim@sha256:dd9d21971ec4395903fa6143c2b9267d048ae01ca6d3ea96f16cb30df6187d94
 FROM ${NODE_IMAGE} AS build

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Users report it also to work with:
 
 ## Install
 
-[Installation](./docs/installation.md)
+[Installation on the Remote (custom archive)](./docs/installation.md)
+
+[Docker on a separate host: setup, networking, updates and image publishing](./docs/docker.md)
 
 [Upgrade to new version](./docs/new-version.md)
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,28 @@
+name: onkyo
+services:
+  onkyo:
+    # Local build works before the maintainer publishes the first GHCR image.
+    image: ${ONKYO_IMAGE:-uc-intg-onkyo-avr:local}
+    build: .
+    network_mode: host
+    init: true
+    restart: unless-stopped
+    stop_grace_period: 20s
+    environment:
+      UC_CONFIG_HOME: /config
+      UC_INTEGRATION_INTERFACE: 0.0.0.0
+      UC_INTEGRATION_HTTP_PORT: "9090"
+      UC_DISABLE_MDNS_PUBLISH: "false"
+    volumes:
+      - config:/config
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+volumes:
+  config:

--- a/docker/healthcheck.mjs
+++ b/docker/healthcheck.mjs
@@ -1,0 +1,12 @@
+// TCP liveness only: no setup, discovery, subscriptions or AVR commands.
+import { connect } from "node:net";
+const bind = process.env.UC_INTEGRATION_INTERFACE;
+const host = !bind || bind === "0.0.0.0" ? "127.0.0.1" : bind === "::" ? "::1" : bind;
+const socket = connect({ host, port: Number(process.env.UC_INTEGRATION_HTTP_PORT || 9090) });
+socket.setTimeout(3000);
+socket.once("connect", () => {
+  socket.destroy();
+  process.exit(0);
+});
+socket.once("error", () => process.exit(1));
+socket.once("timeout", () => process.exit(1));

--- a/docker/image-tags.mjs
+++ b/docker/image-tags.mjs
@@ -1,0 +1,20 @@
+// CI supplies the version from package.json after checking driver.json.
+const { GITHUB_REPOSITORY: repository, GITHUB_EVENT_NAME: event, GITHUB_REF: ref, GITHUB_SHA: sha, IMAGE_VERSION: version } = process.env;
+const fail = (message) => {
+  console.error(message);
+  process.exit(1);
+};
+if (!repository || !/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/i.test(repository)) fail("Invalid repository");
+const image = `ghcr.io/${repository.toLowerCase()}`;
+if (event === "push" && ref?.startsWith("refs/tags/v")) {
+  const tag = ref.slice("refs/tags/v".length);
+  // Deliberately exclude build metadata (+ is not a valid Docker tag character).
+  if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/.test(tag) || tag !== version) fail("Release tag must match package.json version (without build metadata)");
+  console.log(`${image}:${tag}`);
+  if (!tag.includes("-")) console.log(`${image}:latest`);
+} else if (event === "workflow_dispatch" && ref?.startsWith("refs/heads/") && /^[a-f0-9]{12,40}$/.test(sha || "")) {
+  // The workflow additionally restricts manual publishing to the default branch.
+  console.log(`${image}:dev-${sha.slice(0, 12)}`);
+} else {
+  fail("This event/ref is not allowed to publish");
+}

--- a/docker/release-gate.sh
+++ b/docker/release-gate.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Run in the read-only gate job, before the publishing job can start.
+set -euo pipefail
+: "${DEFAULT_BRANCH:?default branch is required}"
+: "${GITHUB_SHA:?release commit is required}"
+git check-ref-format "refs/heads/$DEFAULT_BRANCH"
+# checkout fetch-depth: 0 fetches all branches; fail closed if the ref is absent.
+default_ref="refs/remotes/origin/$DEFAULT_BRANCH"
+git rev-parse --verify "${default_ref}^{commit}" >/dev/null
+git rev-parse --verify "${GITHUB_SHA}^{commit}" >/dev/null
+git merge-base --is-ancestor "$GITHUB_SHA" "$default_ref"

--- a/docker/smoke-probe.mjs
+++ b/docker/smoke-probe.mjs
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
-import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
+import { once } from "node:events";
 import WebSocket from "ws";
-assert.notEqual(process.getuid(), 0, "runtime must not be root");
+import { ConfigManager, getConfigPath } from "./dist/configManager.js";
+assert.equal(process.getuid(), 1000, "runtime must use UID 1000");
 const metadata = JSON.parse(readFileSync("driver.json", "utf8"));
 const pkg = JSON.parse(readFileSync("package.json", "utf8"));
 assert.equal(metadata.version, pkg.version);
@@ -12,29 +14,61 @@ for (const logo of ["back.svg", "deezer.svg", "eiscp.svg", "menu.svg", "music-se
 }
 assert.ok(readdirSync("node_modules").length > 0);
 assert.ok(!existsSync("node_modules/typescript"), "development dependencies shipped");
-if (process.env.SMOKE_RECREATED === "true") {
-  assert.equal(readFileSync("/config/docker-smoke-marker", "utf8"), "persistent-non-root-write");
-} else {
-  writeFileSync("/config/docker-smoke-marker", "persistent-non-root-write");
-}
+const recreated = process.env.SMOKE_RECREATED === "true";
+// Empty AVR list is valid restore input and cannot send discovery/control commands.
+const expected = { avrs: [], logLevel: "error" };
+assert.equal(getConfigPath(), "/config/config.json");
+if (!recreated) assert.ok(!existsSync(getConfigPath()), "fresh owned volume must be empty");
 const ws = new WebSocket("ws://127.0.0.1:9090");
 const timeout = setTimeout(() => {
-  console.error("WebSocket metadata timeout");
+  console.error("WebSocket setup/restore timeout");
   process.exit(1);
-}, 5000);
+}, 10000);
 ws.on("error", (error) => {
   console.error(error);
   process.exit(1);
 });
-ws.on("open", () => ws.send(JSON.stringify({ kind: "req", id: 1, msg: "get_driver_metadata", msg_data: {} })));
-ws.on("message", (raw) => {
-  const message = JSON.parse(raw.toString());
-  if (message.req_id !== 1) return;
-  assert.equal(message.code, 200);
-  assert.equal(message.msg, "driver_metadata");
-  assert.equal(message.msg_data.driver_id, metadata.driver_id);
-  assert.equal(message.msg_data.version, pkg.version);
+let id = 0;
+function exchange(msg, msg_data, matches) {
+  return new Promise((resolve) => {
+    const requestId = ++id;
+    const listener = (raw) => {
+      const message = JSON.parse(raw.toString());
+      if (message.req_id === requestId) assert.equal(message.code, 200);
+      if (matches(message, requestId)) {
+        ws.off("message", listener);
+        resolve(message);
+      }
+    };
+    ws.on("message", listener);
+    ws.send(JSON.stringify({ kind: "req", id: requestId, msg, msg_data }));
+  });
+}
+const setupState = (state) => (message) => message.msg === "driver_setup_change" && message.msg_data.state === state;
+try {
+  await once(ws, "open");
+  const response = await exchange("get_driver_metadata", {}, (message, requestId) => message.req_id === requestId);
+  assert.equal(response.msg, "driver_metadata");
+  assert.equal(response.msg_data.driver_id, metadata.driver_id);
+  assert.equal(response.msg_data.version, pkg.version);
+  if (!recreated) {
+    // SetupHandler.handleDriverSetupReconfigure -> restoreConfiguration -> ConfigManager.save.
+    await exchange("setup_driver", { reconfigure: true, setup_data: { choice: "restore", restore_data: JSON.stringify(expected) } }, setupState("OK"));
+  }
+  assert.deepEqual(JSON.parse(readFileSync(getConfigPath(), "utf8")), expected);
+  assert.equal(statSync(getConfigPath()).uid, 1000);
+  assert.ok(!existsSync("/app/config.json"), "configuration must not fall back to the working directory");
+  assert.deepEqual(ConfigManager.load(), expected);
+  if (recreated) {
+    // Ask the restarted default-CMD driver to load settings into its real setup form.
+    await exchange("setup_driver", { reconfigure: true, setup_data: {} }, setupState("WAIT_USER_ACTION"));
+    const form = await exchange("set_driver_user_data", { input_values: { action: "configure" } }, setupState("WAIT_USER_ACTION"));
+    const settings = form.msg_data.require_user_action.input.settings;
+    assert.equal(settings.find((setting) => setting.id === "logLevel").field.dropdown.value, expected.logLevel);
+    // Do not submit the manual form: blank AVR fields would request discovery.
+  }
+  console.log(JSON.stringify({ uid: process.getuid(), version: pkg.version, configPath: getConfigPath(), config: expected, recreated }));
+} finally {
   clearTimeout(timeout);
   ws.close();
-  console.log(JSON.stringify({ uid: process.getuid(), version: pkg.version, protocol: message.msg, recreated: process.env.SMOKE_RECREATED === "true" }));
-});
+}

--- a/docker/smoke-probe.mjs
+++ b/docker/smoke-probe.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import WebSocket from "ws";
+assert.notEqual(process.getuid(), 0, "runtime must not be root");
+const metadata = JSON.parse(readFileSync("driver.json", "utf8"));
+const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+assert.equal(metadata.version, pkg.version);
+assert.ok(existsSync(pkg.main), "compiled entrypoint missing");
+assert.ok(readFileSync("eiscp.png").length > 0);
+for (const logo of ["back.svg", "deezer.svg", "eiscp.svg", "menu.svg", "music-server.svg", "tidal.svg", "tunein.svg"]) {
+  assert.ok(readFileSync(`logos/${logo}`, "utf8").includes("<svg"));
+}
+assert.ok(readdirSync("node_modules").length > 0);
+assert.ok(!existsSync("node_modules/typescript"), "development dependencies shipped");
+if (process.env.SMOKE_RECREATED === "true") {
+  assert.equal(readFileSync("/config/docker-smoke-marker", "utf8"), "persistent-non-root-write");
+} else {
+  writeFileSync("/config/docker-smoke-marker", "persistent-non-root-write");
+}
+const ws = new WebSocket("ws://127.0.0.1:9090");
+const timeout = setTimeout(() => {
+  console.error("WebSocket metadata timeout");
+  process.exit(1);
+}, 5000);
+ws.on("error", (error) => {
+  console.error(error);
+  process.exit(1);
+});
+ws.on("open", () => ws.send(JSON.stringify({ kind: "req", id: 1, msg: "get_driver_metadata", msg_data: {} })));
+ws.on("message", (raw) => {
+  const message = JSON.parse(raw.toString());
+  if (message.req_id !== 1) return;
+  assert.equal(message.code, 200);
+  assert.equal(message.msg, "driver_metadata");
+  assert.equal(message.msg_data.driver_id, metadata.driver_id);
+  assert.equal(message.msg_data.version, pkg.version);
+  clearTimeout(timeout);
+  ws.close();
+  console.log(JSON.stringify({ uid: process.getuid(), version: pkg.version, protocol: message.msg, recreated: process.env.SMOKE_RECREATED === "true" }));
+});

--- a/docker/smoke.sh
+++ b/docker/smoke.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Isolated smoke test: no published ports, LAN access, or AVR commands.
+set -euo pipefail
+image=${1:-uc-intg-onkyo-avr:local}
+prefix="onkyo-smoke-$$"
+volume="$prefix-config"
+container="$prefix"
+cleanup() {
+  docker logs "$container" 2>/dev/null || true
+  docker rm -f "$container" >/dev/null 2>&1 || true
+  docker volume rm "$volume" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+# Refuse reuse: this script only deletes resources it creates.
+if docker container inspect "$container" >/dev/null 2>&1 || docker volume inspect "$volume" >/dev/null 2>&1; then
+  trap - EXIT
+  exit 1
+fi
+docker volume create "$volume" >/dev/null
+start() {
+  docker run -d --name "$container" --network none --init \
+    --cap-drop ALL --security-opt no-new-privileges:true \
+    -e UC_DISABLE_MDNS_PUBLISH=true -v "$volume:/config" "$image" >/dev/null
+  for attempt in {1..30}; do
+    if docker exec "$container" node docker/healthcheck.mjs; then return; fi
+    sleep 1
+  done
+  return 1
+}
+start
+# Test default CMD, actual WebSocket protocol, assets, UID and config write.
+docker exec -i "$container" node --input-type=module < docker/smoke-probe.mjs
+docker stop --time 20 "$container" >/dev/null
+test "$(docker inspect -f '{{.State.ExitCode}}' "$container")" != 137
+docker rm "$container" >/dev/null
+start
+docker exec -i -e SMOKE_RECREATED=true "$container" node --input-type=module < docker/smoke-probe.mjs
+printf 'PASS: default CMD, WebSocket metadata, assets, non-root, persistent volume, SIGTERM/recreate\n'

--- a/docker/smoke.sh
+++ b/docker/smoke.sh
@@ -35,4 +35,4 @@ test "$(docker inspect -f '{{.State.ExitCode}}' "$container")" != 137
 docker rm "$container" >/dev/null
 start
 docker exec -i -e SMOKE_RECREATED=true "$container" node --input-type=module < docker/smoke-probe.mjs
-printf 'PASS: default CMD, WebSocket metadata, assets, non-root, persistent volume, SIGTERM/recreate\n'
+printf 'PASS: default CMD, WebSocket metadata/restore, assets, UID1000 /config/config.json, SIGTERM/recreate and setup-form reload\n'

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,239 @@
+# Run the Onkyo integration with Docker
+
+This runs the integration on a **separate Docker host**, not on Remote 3. A Linux server, supported NAS, or Raspberry Pi with a **64-bit ARM64 OS** can host it. Remote Two/3 connects to the host over the local network; the host connects to the AVR.
+
+There are two different installation methods:
+
+- [Custom installation](installation.md): upload the release `.tar.gz` to the Remote's web-configurator; the Remote runs the driver.
+- **External Docker integration (this guide)**: keep the container running on your server and register its WebSocket address with the Remote. Do not upload a Docker image or Compose file to “Install custom”.
+
+Use only **one active copy of this driver**. Back up the existing integration before changing methods. Disable the old instance before registering the external one; duplicate driver IDs can cause conflicts. Moving methods may require reselecting entities in activities. A Docker volume backup is not a backup of the Remote's activities.
+
+## Requirements
+
+- A maintained Docker Engine with Buildx and the Compose v2 plugin (`docker version`, `docker buildx version`, `docker compose version`). Use your platform's supported [Docker installation instructions](https://docs.docker.com/engine/install/). The examples use Linux and `docker compose`, not the legacy `docker-compose` command.
+- An x86-64 (`linux/amd64`) or ARM64 (`linux/arm64`) Docker host. A 32-bit Raspberry Pi OS is not a supported image target.
+- A reachable LAN shared by the Docker host, Remote and AVR; DHCP reservations/fixed IP addresses for the host and AVR are recommended. IP subnet membership depends on the subnet mask, not simply matching the first three address components.
+- Enable the AVR's **Network Standby** and **Network Control** options as applicable to the model. See its manual: menu names vary. After loss of mains power some models must be turned on once manually. Discovery and standby control are model-dependent.
+- Keep Remote firmware current. This driver's `driver.json` declares **`min_core_api: 0.20.0`**, an API version, **not firmware 0.20.0**. The official custom-installation specification notes that this field is not enforced. The Docker image supplies its own Node.js runtime, so the Remote's bundled Node version does not determine the container runtime. No exact minimum Remote 3 firmware is asserted here; individual features can need newer firmware.
+- Git for the local-build quick start; `curl` and `jq` only for optional manual registration.
+
+## Quick start: Linux host networking
+
+Use a checkout/release containing these Docker files. Until this change is merged upstream, use the reviewed feature revision rather than expecting upstream `main` to contain them.
+
+```sh
+git clone https://github.com/EddyMcNut/uc-intg-onkyo-avr.git
+cd uc-intg-onkyo-avr
+docker compose config --quiet
+docker compose build --pull
+docker compose up -d --no-build --pull never
+docker compose ps
+docker compose logs --tail=100 onkyo
+```
+
+The supplied [compose.yaml](../compose.yaml) builds `uc-intg-onkyo-avr:local`, uses Linux host networking, runs as UID/GID **1000:1000** (`node`), and stores settings in the named volume **`onkyo_config`**. It does not require Node/npm on the host. Keep the Compose project name `onkyo` unchanged to reuse that volume.
+
+**Image availability:** this guide does not imply a GHCR image has already been published. The intended upstream image name is **`ghcr.io/eddymcnut/uc-intg-onkyo-avr`**. Once the maintainer has published an image, select an actual version listed in the upstream package (replace `X.Y.Z`):
+
+```sh
+export ONKYO_IMAGE=ghcr.io/eddymcnut/uc-intg-onkyo-avr:X.Y.Z
+docker compose pull onkyo
+docker compose up -d --no-build
+```
+
+Persist that choice as `ONKYO_IMAGE=ghcr.io/eddymcnut/uc-intg-onkyo-avr:X.Y.Z` in a local `.env` file so later shells use the same image. If pull reports “manifest unknown” or an unavailable/private package, use the local build above (unset `ONKYO_IMAGE` first). Do not substitute a fork image and assume it has identical contents. Prefer a version or digest over mutable `latest`.
+
+### Add it to Remote Two/3
+
+1. Open the **Remote's** web-configurator (at its own LAN address), then Integrations / Add new. Labels can vary with firmware.
+2. On a multicast-capable LAN, the external “Onkyo/Pioneer/Integra AVR (eISCP)” driver should be discovered. Select it and complete setup. This is not “Install custom”.
+3. Choose Configure and enter the AVR model and fixed AVR IP, or leave those fields empty for AVR discovery on a compatible host network/model. If discovery fails, use manual AVR setup, not a second container.
+4. Select zones/entities and complete setup. Set the album-art endpoint for your AVR or `na` when unsupported; see [Album Art](album-art.md).
+5. If the external driver is not listed, use the registration procedure below. Once registered, the usual [configuration and entity instructions](installation.md) apply without uploading an archive.
+
+The driver listens on **`ws://HOST_LAN_IP:9090`**. This is the **Docker host's** address, not the Remote's address, `localhost`, `0.0.0.0`, or a private container address. Port 9090 is a WebSocket Integration API, **not a browser configuration GUI**. An HTTP error at `http://HOST:9090` does not by itself mean the driver is broken.
+
+## Networking and security
+
+The SDK used here is `@unfoldedcircle/integration-api` **0.5.0**. Its installed implementation was checked against the source used for this guide.
+
+| Traffic                            | Purpose / direction                                                         |
+| ---------------------------------- | --------------------------------------------------------------------------- |
+| TCP 9090 (configurable)            | Remote → Docker host, WebSocket Integration API                             |
+| UDP 5353 multicast                 | Integration advertisement, `_uc-integration._tcp` (mDNS); not AVR discovery |
+| UDP 60128 broadcast/replies        | Docker host ↔ AVR, eISCP discovery during setup                             |
+| TCP 60128 (AVR setting)            | Docker host → AVR, normal eISCP control and state                           |
+| TCP 80 to AVR (usual HTTP default) | Docker host **and Remote** → AVR, model-specific album art                  |
+
+**There is no separate thumbnail/album-art HTTP server in this upstream version.** `src/serviceThumbnails.ts` loads packaged SVG logos and generates inline `data:image/svg+xml` thumbnails. `src/zoneMediaRenderer.ts` hashes the AVR's HTTP image and sends a URL such as `http://AVR_IP/album_art.cgi?hash=...` to the Remote. Therefore the Remote also needs direct access to that AVR URL. There is no image-server port or advertised-image-host environment setting to configure. Endpoint paths vary by AVR; use `na` if absent. Do not map invented media ports.
+
+### Host mode (recommended on Linux)
+
+Host mode avoids a container network bridge for multicast and broadcast, but does not guarantee discovery. **Do not add `ports:`** to a host-network service: there is no port mapping. Check that 9090 is free on the host. To use another port, edit `UC_INTEGRATION_HTTP_PORT` in Compose and register `ws://HOST_LAN_IP:NEW_PORT`. Do not change the AVR's 60128 control port to fix a driver port conflict.
+
+`UC_INTEGRATION_INTERFACE` takes a **bind address**, not a NIC name such as `eth0`. Leave it at `0.0.0.0` in normal use. Under host networking it can be a host LAN address, but SDK 0.5.0 does **not** constrain its Bonjour publisher to that interface. Multiple NICs, VPN adapters and conflicting `.local` names can advertise the wrong address; manual registration is the reliable fallback.
+
+### Bridge mode / NAS / Docker Desktop / VLANs
+
+Docker Desktop runs containers inside a VM; its host-network feature and NAS implementations are not equivalent to native Linux multicast/broadcast behavior. Some NAS interfaces do not support host mode. Across VLANs, routing alone does not forward mDNS or AVR broadcast discovery. Prefer manual registration and a fixed AVR IP rather than broadly relaying multicast.
+
+For a bridge fallback, **edit the existing Compose file** (do not layer an override that accidentally retains `network_mode: host`):
+
+1. Remove `network_mode: host`.
+2. Set `UC_DISABLE_MDNS_PUBLISH: "true"`.
+3. Keep `UC_INTEGRATION_INTERFACE: 0.0.0.0` and `UC_INTEGRATION_HTTP_PORT: "9090"`.
+4. Add this under the `onkyo` service, replacing the example host address with your Docker host's LAN IP:
+
+```yaml
+ports:
+  - "192.168.1.20:9090:9090/tcp"
+```
+
+Run `docker compose config --quiet` and `docker compose up -d --no-build --pull never` again. Register `ws://192.168.1.20:9090` (your actual host address). If host port 9090 is busy, use e.g. `192.168.1.20:9091:9090/tcp` and register port 9091; the container still listens on 9090. **Only the WebSocket TCP port needs publishing.** AVR TCP/HTTP connections originate outbound. Publishing UDP 60128 or 5353 does not make LAN broadcast/multicast traverse Docker NAT. Use manual AVR setup in bridge mode.
+
+For VLANs/firewalls, allow only the required source/destination traffic in the table and established replies. “Driver discovered” does not prove AVR control works; “manual control works” does not prove multicast works. Wi-Fi client isolation can block both. Do not disable the firewall wholesale.
+
+**Trusted LAN only:** the Node SDK does not implement secure WebSocket or token authentication; connections are accepted without an integration password. Do not expose the service publicly, use router port forwarding, or assume Remote PIN authentication protects this WebSocket port. No privileged container, Docker socket, `PUID`/`PGID`, invented token, or blanket host permission changes are required.
+
+### Manual registration through the official Core REST API
+
+The [official registration guide](https://github.com/unfoldedcircle/core-api/blob/main/doc/integration-driver/driver-registration.md) specifies `POST /api/intg/drivers`. The [official Remote Two/3 TypeScript example](https://github.com/unfoldedcircle/integration-ts-example#driver-registration) confirms this workflow and `web-configurator` authentication using the Remote's PIN. Its simulator URL `localhost:8080` is **not** the address of a physical Remote.
+
+Run from the checkout with the container running. Replace the two addresses below. `curl --user web-configurator` prompts privately for the PIN; do not put the PIN into a command, issue, screenshot, or checked-in file.
+
+```sh
+REMOTE_IP=192.168.1.30
+HOST_LAN_IP=192.168.1.20
+HOST_PORT=9090
+docker compose cp onkyo:/app/driver.json ./driver-registration.json
+jq --arg url "ws://${HOST_LAN_IP}:${HOST_PORT}" \
+  '. + {driver_url: $url, enabled: true, icon: "uc:music"}' \
+  driver-registration.json > driver-registration-request.json
+curl --fail-with-body --user web-configurator \
+  --header 'Content-Type: application/json' \
+  --data-binary @driver-registration-request.json \
+  "http://${REMOTE_IP}/api/intg/drivers"
+curl --fail-with-body --user web-configurator \
+  "http://${REMOTE_IP}/api/intg/drivers"
+```
+
+The second request verifies registration. Go back to the Remote web-configurator, select the registered driver and complete its setup; registration alone does not create configured AVR entities. If the driver ID already exists, inspect the existing instance and disable/remove the old copy deliberately instead of repeatedly POSTing or deleting other integrations.
+
+The example uses a built-in music icon: the custom `eiscp.png` packaged in the container is **not automatically installed as a Remote icon** by external registration. The custom archive method has a separate icon installation mechanism. Missing custom pictograms are not a control/connectivity failure.
+
+REST Basic authentication over HTTP is not encrypted; use this only on your trusted management LAN. No credentials are needed for the driver WebSocket itself. The official simulator also requires manual registration because its container does not provide working automatic discovery.
+
+## Configuration, persistence and operation
+
+Supported container environment settings:
+
+| Setting                    | Image / Compose default                           | Meaning                                               |
+| -------------------------- | ------------------------------------------------- | ----------------------------------------------------- |
+| `UC_CONFIG_HOME`           | `/config`                                         | Persisted driver configuration directory              |
+| `UC_INTEGRATION_INTERFACE` | `0.0.0.0`                                         | WebSocket bind address                                |
+| `UC_INTEGRATION_HTTP_PORT` | `9090`                                            | WebSocket listening port                              |
+| `UC_DISABLE_MDNS_PUBLISH`  | SDK default `false`; Compose explicitly `"false"` | Set exactly `"true"` for manual/bridge mode           |
+| `DEBUG`                    | Optional                                          | SDK logging, e.g. `ucapi:info,ucapi:warn,ucapi:error` |
+
+AVR settings are entered in the Remote's integration setup, not invented environment variables. The application also has a persisted [log-level setting](loglevel.md).
+
+Docker initializes a fresh named volume with `/config` ownership from the image (UID/GID 1000:1000). `config.json` survives container recreation. Do not mount an empty directory over `/app` or change the image's user to root. For an optional bind mount, pre-create a dedicated directory writable by 1000:1000, accounting for NAS ACLs, rootless Docker UID mapping and SELinux labeling where applicable. A bind mount hides image directory ownership; `Permission denied` is not fixed by adding `PUID`/`PGID` (unsupported) or `chmod 777`.
+
+### Backup and restore
+
+The [integration backup/restore UI](backup-restore.md) exports logical driver settings. For a full container-config backup, stop writes and archive the named volume. Run from the same Compose directory/project, with the selected image available locally:
+
+```sh
+docker compose stop onkyo
+docker compose run --rm --no-deps -T --entrypoint tar onkyo \
+  -czf - -C /config . > onkyo-config-backup.tar.gz
+docker compose start onkyo
+```
+
+Check that the backup command succeeded and test the archive (`tar -tzf onkyo-config-backup.tar.gz`) before relying on it. Store it privately off the Docker host. To restore a **trusted** backup, stop the service first, back up current settings, then extract as the image's non-root user:
+
+```sh
+docker compose stop onkyo
+docker compose run --rm --no-deps -T --entrypoint tar onkyo \
+  --no-same-owner -xzf - -C /config < onkyo-config-backup.tar.gz
+docker compose start onkyo
+```
+
+Extraction overwrites matching files, not unrelated files. For a clean disaster recovery, restore into a fresh named volume/project and verify ownership before switching over. Keep Compose's project name and volume consistent. **Never use `docker compose down -v` or volume pruning for an update/rollback**: these delete settings.
+
+### Update and rollback
+
+1. Read upstream release notes; take a backup and record the currently selected image tag/digest (`docker compose images`). Keep the old image locally.
+2. For registry images, change `ONKYO_IMAGE` to the desired published version (and update `.env`), run `docker compose pull onkyo`, then `docker compose up -d --no-build`.
+3. For local builds, check out the desired reviewed release/revision, build a new explicit local tag with `docker build -t uc-intg-onkyo-avr:NEW_VERSION .`, set `ONKYO_IMAGE` to it and run `docker compose up -d --no-build --pull never`.
+4. Check health/logs and then test the Remote/AVR. For rollback, select the previous tag/digest and recreate with the same volume. If the new version migrated settings incompatibly, restore the matching pre-update backup while stopped. Do not run both versions against the volume simultaneously.
+
+Compose uses `init: true`, an exec-form Node command, SIGTERM and a 20-second stop grace period. Signals reach Node directly instead of an npm/shell wrapper. The current application has no custom shutdown/drain hook; this is not a guarantee that an in-flight command completes. Config writes are persisted by the application during configuration changes.
+
+### Logs and troubleshooting
+
+```sh
+docker compose ps
+docker compose logs --tail=200 onkyo
+docker compose exec onkyo node docker/healthcheck.mjs
+```
+
+For SDK connection/startup messages, add `DEBUG: "ucapi:info,ucapi:warn,ucapi:error"` to Compose environment and recreate. Broad `DEBUG=ucapi:*` includes protocol traces; review/redact logs before sharing, as configuration/logs can contain private addresses or settings. Log rotation is configured in the example.
+
+- **Unhealthy/exits:** inspect logs for missing files, permission errors, or `EADDRINUSE`. Confirm the configured port is free and the bind address exists in the selected network mode.
+- **Healthy but missing in the Remote:** health checks only open a local TCP connection. They do not test mDNS, Remote firmware, registration, AVR availability, album art or successful commands. Use manual registration and verify LAN routing.
+- **Remote connected but AVR unavailable:** check the fixed AVR IP, network-control/standby settings and outbound TCP 60128. Use manual AVR setup if broadcast discovery is unavailable.
+- **Artwork missing:** verify the model-specific HTTP endpoint from both the Docker host and Remote network. Do not publish an extra container port. Set `na` for models without an endpoint.
+- **Settings disappeared after update:** check you reused the same Compose project and named volume, and did not run `down -v`. Stop and inspect before doing a fresh setup.
+
+## Maintainers: build, verify and publish
+
+The Docker workflow is independent of the existing custom-archive release workflow. It does **not** sync/merge forks, create releases, update dependencies, or deploy anything.
+
+### Reproducible local checks
+
+With a compatible Node version (`.nvmrc` is the reference) and Docker:
+
+```sh
+npm ci
+npm run build
+npm test
+npm run code-check
+docker compose config --quiet
+docker build --progress=plain -t uc-intg-onkyo-avr:local .
+bash docker/smoke.sh uc-intg-onkyo-avr:local
+```
+
+The smoke test creates uniquely named disposable containers and a named volume, uses **`--network none`** and `UC_DISABLE_MDNS_PUBLISH=true`, and does not publish ports or send AVR discovery/control commands. It checks the image's default command, actual `get_driver_metadata` WebSocket response, runtime assets, absence of TypeScript in production dependencies, non-root config writes, SIGTERM stop (no forced kill), and persistence after container recreation. It cleans up **only its own** test resources. Run it from the repository root; it does not use your configured Compose volume.
+
+The Dockerfile uses lockfile-based `npm ci`, a separate production dependency stage, and only compiled code/runtime assets in the final image. It checks that `package.json` and `driver.json` versions match and fails on mismatch. Both are currently 0.9.3; future releases must update them together (and the lockfile's package version when changing package version). The default command is `node dist/driver.js`, **not** the obsolete `dist/src/index.js`.
+
+The official Node base matches `.nvmrc` and is pinned to a multi-platform index digest. Update its version **and digest** deliberately when updating the runtime; verify the package `engines` range and rebuild/test both architectures. Keep the allowlisted `.dockerignore` in sync with any new build inputs; it intentionally excludes local config, credentials, Git history, tests, screenshots and research files.
+
+### CI and registry policy
+
+[`.github/workflows/docker.yml`](../.github/workflows/docker.yml):
+
+- PRs and `main` / `feat/**` pushes run dependency installation, tests, code checks, Compose validation, and **native amd64 and arm64 image builds plus isolated smoke tests**. These jobs have only `contents: read`; no registry login/write or registry secrets.
+- Pushing an authorized release tag `vX.Y.Z` publishes `ghcr.io/<lowercase-owner>/<lowercase-repository>:X.Y.Z` and `:latest`, **after both builds pass**. A prerelease must use a suffix such as `vX.Y.Z-rc.1`; it publishes only `:X.Y.Z-rc.1`, never `latest`. Do not use a stable-looking tag for a prerelease. Tags must match `package.json` exactly after removing `v`; build metadata (`+...`) is rejected because it is not a valid image tag.
+- Manual dispatch defaults to **build/test only** (`publish: false`). Explicit `publish: true` can publish **only from the repository default branch**, under `:dev-<12-character-commit-SHA>`. It never creates/updates `latest` or a stable version tag.
+- Only the publishing job has `packages: write`. It uses the repository's **`GITHUB_TOKEN`**, not a PAT, and lowercases the repository name for GHCR. Buildx with QEMU builds the multi-platform publication; validation runs natively on GitHub's public Linux x64 and ARM64 runners.
+
+For upstream the resulting path is `ghcr.io/eddymcnut/uc-intg-onkyo-avr`. Maintainers must enable Actions/package publishing as permitted by their repository policy and make the GHCR package **public** if end users should pull anonymously (new packages may initially be private). Confirm package access and inspect the published manifest with `docker buildx imagetools inspect IMAGE:VERSION`; it must contain `linux/amd64` and `linux/arm64`. Protect release tags/default-branch publishing through repository permissions. Re-running a release build can replace its version tag; users needing immutable deployments should pin the manifest digest.
+
+Do not push a release tag merely to test Docker: the pre-existing archive workflow also reacts to release tags. Feature branches and PRs do not publish images. Forks derive their own GHCR path; this workflow does not mirror upstream images.
+
+### Verification boundaries
+
+Automated smoke tests do not prove physical Remote 3 / AVR interoperability, multicast behavior on a user's network, or artwork rendering on firmware. Test those with hardware before claiming model/firmware support. Cross-platform manifest availability alone is not an ARM64 execution test; require both native CI builds/smokes to pass before publication.
+
+## Official references and scope
+
+- [UC TypeScript integration example for Remote Two/3](https://github.com/unfoldedcircle/integration-ts-example): external drivers, Remote vs simulator, registration and PIN authentication. Its Docker Compose instructions are for the **Core Simulator on another machine**, not for installing Docker on Remote 3.
+- [Node SDK environment variables and limitations](https://github.com/unfoldedcircle/integration-node-library#environment-variables): supported bind/port/config/mDNS options and unsupported secure WebSocket/token authentication. The installed 0.5.0 implementation is authoritative for this image.
+- [Driver mDNS advertisement](https://github.com/unfoldedcircle/core-api/blob/main/doc/integration-driver/driver-advertisement.md) and [driver registration](https://github.com/unfoldedcircle/core-api/blob/main/doc/integration-driver/driver-registration.md).
+- [Custom driver installation](https://github.com/unfoldedcircle/core-api/blob/main/doc/integration-driver/driver-installation.md): the distinct `.tar.gz` sandbox/metadata/icon mechanism; its firmware requirements are not Docker-host installation instructions.
+- [WebSocket integration protocol](https://github.com/unfoldedcircle/core-api/blob/main/doc/integration-driver/websocket.md) and [Core REST API](https://unfoldedcircle.github.io/core-api/rest/).
+
+This repository's Docker packaging and host/bridge recommendations apply those official external-driver mechanisms to Onkyo. They are not an official Unfolded Circle Onkyo Docker image or an instruction to alter the Remote's operating system.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -20,11 +20,23 @@ Use only **one active copy of this driver**. Back up the existing integration be
 
 ## Quick start: Linux host networking
 
-Use a checkout/release containing these Docker files. Until this change is merged upstream, use the reviewed feature revision rather than expecting upstream `main` to contain them.
+After merge, use a normal upstream checkout or an upstream release containing these Docker files:
 
 ```sh
 git clone https://github.com/EddyMcNut/uc-intg-onkyo-avr.git
 cd uc-intg-onkyo-avr
+```
+
+**Optional PR preview (before merge):** upstream `main` does not yet contain the Docker files. After cloning, run these commands **before any Compose commands** to check out the current PR #43 revision. This is a development preview, not an upstream release; review the fetched revision before running it.
+
+```sh
+git fetch origin pull/43/head
+git switch --detach FETCH_HEAD
+```
+
+Then build and start locally (neither path requires a published registry image):
+
+```sh
 docker compose config --quiet
 docker compose build --pull
 docker compose up -d --no-build --pull never
@@ -42,7 +54,15 @@ docker compose pull onkyo
 docker compose up -d --no-build
 ```
 
-Persist that choice as `ONKYO_IMAGE=ghcr.io/eddymcnut/uc-intg-onkyo-avr:X.Y.Z` in a local `.env` file so later shells use the same image. If pull reports “manifest unknown” or an unavailable/private package, use the local build above (unset `ONKYO_IMAGE` first). Do not substitute a fork image and assume it has identical contents. Prefer a version or digest over mutable `latest`.
+Persist that choice as `ONKYO_IMAGE=ghcr.io/eddymcnut/uc-intg-onkyo-avr:X.Y.Z` in a local `.env` file so later shells use the same image. If pull reports “manifest unknown” or an unavailable/private package, explicitly select the local image and rebuild:
+
+```sh
+export ONKYO_IMAGE=uc-intg-onkyo-avr:local
+docker compose build --pull
+docker compose up -d --no-build --pull never
+```
+
+Also remove/comment the registry `ONKYO_IMAGE` entry in `.env`, or update it to `ONKYO_IMAGE=uc-intg-onkyo-avr:local`, for future shells. Merely unsetting the shell variable is insufficient: Compose reads `.env` again. Do not substitute a fork image and assume it has identical contents. Prefer a version or digest over mutable `latest`.
 
 ### Add it to Remote Two/3
 
@@ -205,7 +225,7 @@ docker build --progress=plain -t uc-intg-onkyo-avr:local .
 bash docker/smoke.sh uc-intg-onkyo-avr:local
 ```
 
-The smoke test creates uniquely named disposable containers and a named volume, uses **`--network none`** and `UC_DISABLE_MDNS_PUBLISH=true`, and does not publish ports or send AVR discovery/control commands. It checks the image's default command, actual `get_driver_metadata` WebSocket response, runtime assets, absence of TypeScript in production dependencies, non-root config writes, SIGTERM stop (no forced kill), and persistence after container recreation. It cleans up **only its own** test resources. Run it from the repository root; it does not use your configured Compose volume.
+The smoke test creates uniquely named disposable containers and a named volume, uses **`--network none`** and `UC_DISABLE_MDNS_PUBLISH=true`, and does not publish ports or send AVR discovery/control commands. It checks the image's default command, actual `get_driver_metadata` WebSocket response, runtime assets, absence of TypeScript in production dependencies, and SIGTERM stop (no forced kill). Through the real WebSocket reconfiguration/restore flow it saves the valid harmless configuration `{ "avrs": [], "logLevel": "error" }`, asserts the exact `/config/config.json` contents and UID 1000 ownership, and rejects an accidental `/app/config.json` fallback. After recreating with the default command and the same volume, it checks the persisted file and `ConfigManager.load()`, then verifies the running driver's configuration form reloads the non-default log level. It does not submit that manual form or configure any AVR. It cleans up **only its own** test resources. Run it from the repository root; it does not use your configured Compose volume.
 
 The Dockerfile uses lockfile-based `npm ci`, a separate production dependency stage, and only compiled code/runtime assets in the final image. It checks that `package.json` and `driver.json` versions match and fails on mismatch. Both are currently 0.9.3; future releases must update them together (and the lockfile's package version when changing package version). The default command is `node dist/driver.js`, **not** the obsolete `dist/src/index.js`.
 
@@ -216,11 +236,12 @@ The official Node base matches `.nvmrc` and is pinned to a multi-platform index 
 [`.github/workflows/docker.yml`](../.github/workflows/docker.yml):
 
 - PRs and `main` / `feat/**` pushes run dependency installation, tests, code checks, Compose validation, and **native amd64 and arm64 image builds plus isolated smoke tests**. These jobs have only `contents: read`; no registry login/write or registry secrets.
+- A read-only `release-gate` job checks out full history (`fetch-depth: 0`), verifies that `refs/remotes/origin/<default_branch>` exists, and uses `git merge-base --is-ancestor` to require the release commit to be reachable from that branch. The default-branch name comes through an environment variable, not shell interpolation. A missing ref or unmerged commit fails closed **before the publishing job with `packages: write` can start**. For the upstream repository this is the upstream default branch; forks check their own default branch.
 - Pushing an authorized release tag `vX.Y.Z` publishes `ghcr.io/<lowercase-owner>/<lowercase-repository>:X.Y.Z` and `:latest`, **after both builds pass**. A prerelease must use a suffix such as `vX.Y.Z-rc.1`; it publishes only `:X.Y.Z-rc.1`, never `latest`. Do not use a stable-looking tag for a prerelease. Tags must match `package.json` exactly after removing `v`; build metadata (`+...`) is rejected because it is not a valid image tag.
 - Manual dispatch defaults to **build/test only** (`publish: false`). Explicit `publish: true` can publish **only from the repository default branch**, under `:dev-<12-character-commit-SHA>`. It never creates/updates `latest` or a stable version tag.
 - Only the publishing job has `packages: write`. It uses the repository's **`GITHUB_TOKEN`**, not a PAT, and lowercases the repository name for GHCR. Buildx with QEMU builds the multi-platform publication; validation runs natively on GitHub's public Linux x64 and ARM64 runners.
 
-For upstream the resulting path is `ghcr.io/eddymcnut/uc-intg-onkyo-avr`. Maintainers must enable Actions/package publishing as permitted by their repository policy and make the GHCR package **public** if end users should pull anonymously (new packages may initially be private). Confirm package access and inspect the published manifest with `docker buildx imagetools inspect IMAGE:VERSION`; it must contain `linux/amd64` and `linux/arm64`. Protect release tags/default-branch publishing through repository permissions. Re-running a release build can replace its version tag; users needing immutable deployments should pin the manifest digest.
+For upstream the resulting path is `ghcr.io/eddymcnut/uc-intg-onkyo-avr`. Maintainers must enable Actions/package publishing as permitted by their repository policy and make the GHCR package **public** if end users should pull anonymously (new packages may initially be private). Confirm package access and inspect the published manifest with `docker buildx imagetools inspect IMAGE:VERSION`; it must contain `linux/amd64` and `linux/arm64`. Protect release tags and the default branch through repository rules as defense in depth: restrict tag creation/update/deletion to release maintainers and require reviewed changes to workflow/gate files. The ancestry gate is not a security boundary against someone who can write branches containing modified workflows or a repository administrator; those roles are inherently trusted and can change or bypass repository-owned CI. All Actions in this Docker workflow are pinned to verified full commit SHAs with version comments; update pins deliberately after reviewing the official Action release. Re-running a release build can replace its version tag; users needing immutable deployments should pin the manifest digest.
 
 Do not push a release tag merely to test Docker: the pre-existing archive workflow also reacts to release tags. Feature branches and PRs do not publish images. Forks derive their own GHCR path; this workflow does not mirror upstream images.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,7 @@
 ## Installation and usage
 
+The instructions below install the custom `.tar.gz` archive **on the Remote**. To run the driver on a separate Linux/NAS/Raspberry Pi Docker host instead, follow the [Docker setup guide](docker.md), including external registration and network requirements. Do not upload a Docker image through “Install custom”, and keep only one active copy of the driver.
+
 ### Installation
 
 - Make sure your AVR is ON or STANDBY.

--- a/test/docker-contract.test.ts
+++ b/test/docker-contract.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync, existsSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("Docker runtime contract", () => {
+  it("starts the current compiled entrypoint, not the obsolete dist/src/index.js", () => {
+    expect(existsSync("Dockerfile"), "Dockerfile must exist").toBe(true);
+    const dockerfile = readFileSync("Dockerfile", "utf8");
+    expect(dockerfile).toMatch(/CMD\s+\["node",\s*"dist\/driver.js"\]/);
+    expect(dockerfile).not.toContain("dist/src/index.js");
+    expect(dockerfile).toMatch(/USER node/);
+    expect(dockerfile).toContain("npm ci --omit=dev");
+    expect(dockerfile).toContain("COPY logos ./logos");
+    expect(dockerfile).toContain("UC_CONFIG_HOME=/config");
+  });
+});

--- a/test/docker-publish.test.ts
+++ b/test/docker-publish.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+describe("Docker publishing policy", () => {
+  it("keeps prereleases and manual builds away from latest, and rejects mismatched versions", () => {
+    expect(existsSync("docker/image-tags.mjs"), "image tag validator must exist").toBe(true);
+    const run = (event: string, ref: string, version = "0.9.3") =>
+      execFileSync(process.execPath, ["docker/image-tags.mjs"], {
+        encoding: "utf8",
+        env: { ...process.env, GITHUB_REPOSITORY: "EddyMcNut/uc-intg-onkyo-avr", GITHUB_SHA: "abcdef1234567890", GITHUB_EVENT_NAME: event, GITHUB_REF: ref, IMAGE_VERSION: version }
+      });
+    expect(run("push", "refs/tags/v0.9.3")).toBe("ghcr.io/eddymcnut/uc-intg-onkyo-avr:0.9.3\nghcr.io/eddymcnut/uc-intg-onkyo-avr:latest\n");
+    expect(run("push", "refs/tags/v0.9.3-rc.1", "0.9.3-rc.1")).not.toContain(":latest");
+    expect(run("workflow_dispatch", "refs/heads/main")).toContain(":dev-abcdef123456");
+    expect(() => run("push", "refs/tags/v0.9.4")).toThrow();
+    expect(() => run("push", "refs/tags/v0.9.3+build")).toThrow();
+    expect(() => run("pull_request", "refs/pull/1/merge")).toThrow();
+    expect(() => run("push", "refs/heads/feature")).toThrow();
+    const workflow = readFileSync(".github/workflows/docker.yml", "utf8");
+    expect(workflow).toContain("packages: write");
+    expect(workflow).toContain("inputs.publish");
+    expect(workflow).not.toContain("pull_request_target");
+  });
+});

--- a/test/docker-release-gate.test.ts
+++ b/test/docker-release-gate.test.ts
@@ -1,0 +1,33 @@
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { expect, it } from "vitest";
+
+it("requires release ancestry before granting the publishing job write permissions", () => {
+  const workflow = readFileSync(".github/workflows/docker.yml", "utf8");
+  expect(workflow).toContain("needs: [test, build, release-gate]");
+  expect(workflow).toContain("bash docker/release-gate.sh");
+});
+
+it("accepts an ancestor tag but rejects a divergent commit and missing default ref", () => {
+  const dir = mkdtempSync(join(tmpdir(), "onkyo-release-gate-"));
+  const script = resolve("docker/release-gate.sh");
+  const git = (...args: string[]) => execFileSync("git", args, { cwd: dir, encoding: "utf8" }).trim();
+  try {
+    git("init", "-b", "main");
+    git("-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "--allow-empty", "-m", "base");
+    const base = git("rev-parse", "HEAD");
+    git("-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "--allow-empty", "-m", "default tip");
+    git("update-ref", "refs/remotes/origin/main", "HEAD");
+    const run = (sha: string, branch = "main") => spawnSync("bash", [script], { cwd: dir, env: { ...process.env, GITHUB_SHA: sha, DEFAULT_BRANCH: branch } }).status;
+    expect(run(base)).toBe(0);
+    git("checkout", "--detach", base);
+    git("-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "--allow-empty", "-m", "unmerged");
+    expect(run(git("rev-parse", "HEAD"))).not.toBe(0);
+    expect(run(base, "missing")).not.toBe(0);
+    expect(run(base, "main;false")).not.toBe(0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Add Docker as an **external integration** option for Remote Two / Remote 3, alongside the existing custom-driver archive installation.

- Multi-stage, digest-pinned Node image with locked dependencies, a non-root runtime, persistent `/config`, packaged assets and the current `dist/driver.js` entrypoint.
- A Compose example with restart policy, restricted container privileges and bounded logs.
- A separate Docker workflow that tests native **linux/amd64 and linux/arm64** before any optional GHCR publication. PRs do not publish. Actions are pinned to verified commit SHAs; release publication also requires default-branch ancestry.
- An [English Docker setup and maintainer guide](https://github.com/Serph91P/uc-intg-onkyo-avr/blob/da42980293a1a58bcf24c3d15c5e3602c1fae199/docs/docker.md), linked from the existing installation documentation.

The guide covers local builds and later prebuilt-image installation, concrete PR-preview commands, Remote registration, discovery versus manual WebSocket registration, ports and environment variables, storage permissions, backups, upgrades, rollback, NAS/Docker Desktop limitations and troubleshooting. It references the official Unfolded Circle API/SDK documentation and distinguishes container ports from AVR communication/artwork.

## Verification

Final head: `da42980293a1a58bcf24c3d15c5e3602c1fae199`.

- `npm test`: **680 tests passed**, including the TypeScript build.
- `npm run code-check`, Compose configuration, actionlint and shell syntax checks passed.
- Real native x86-64 **and** ARM64 builds and runtime tests passed in [Docker CI](https://github.com/Serph91P/uc-intg-onkyo-avr/actions/runs/34021612943). The existing [archive workflow](https://github.com/Serph91P/uc-intg-onkyo-avr/actions/runs/34021612950) also passed.
- The isolated smoke test checks the default command, WebSocket metadata, assets, UID 1000, and actual configuration saved through WebSocket restore to `/config/config.json`. After recreation, it verifies the running driver's setup form reloads the saved settings. It uses `--network none` with no AVR configured.
- Release ancestry is covered by real temporary Git fixtures: ancestors pass; divergent commits and missing default refs fail.

## Maintainer notes

No image or release has been published, and nothing has been deployed. Before advertising a GHCR image, the maintainer must enable the permitted publishing path, protect release tags/workflow changes, and make the package public for anonymous pulls. The guide provides a local-build path that does not depend on a published image.

The SDK does not provide TLS or token authentication: this service belongs on a trusted LAN, not a public port. Physical Remote/AVR operation and LAN multicast discovery have not been tested.

GitHub currently requires maintainer approval for the upstream fork-PR workflows; the equivalent checks above passed on the same exact head in the fork. This PR remains Draft while that upstream CI gate awaits approval.
